### PR TITLE
Fix links for footer/header logos

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
   </noscript>
   <header class="header">
     <div class="container">
-      <a href="#" class="header-logo"></a>
+      <a href="/poa-dapps-keys-generation" class="header-logo"></a>
     </div>
   </header>
 
@@ -48,7 +48,7 @@
   <footer class="footer">
     <div class="container">
       <p class="footer-rights">2017 POA Network. All rights reserved.</p>
-      <a href="/poa-dapps-validators" class="footer-logo"></a>
+      <a href="/poa-dapps-keys-generation" class="footer-logo"></a>
       <div class="socials">
         <a href="https://twitter.com/poanetwork" class="socials-i socials-i_twitter"></a>
         <a href="https://poa.network" class="socials-i socials-i_oracles"></a>


### PR DESCRIPTION
**Problem**: links in footer/header logos are incorrect
**Solution**: Change to correct llink: `/poa-dapps-keys-generation`