### PR TITLE
(Fix) error in keys generation immediately after page is loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4582,14 +4582,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4598,6 +4590,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -10265,14 +10265,6 @@
                 }
               }
             },
-            "string_decoder": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
             "string-width": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10281,6 +10273,14 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+              "requires": {
+                "safe-buffer": "5.0.1"
               }
             },
             "stringstream": {
@@ -11370,14 +11370,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -11404,6 +11396,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -12349,29 +12349,29 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
-      "integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
+      "version": "1.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.29.tgz",
+      "integrity": "sha1-6Xv9X94UWlAYFyTxd3+NuRg2YmA=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.26",
-        "web3-core": "1.0.0-beta.26",
-        "web3-eth": "1.0.0-beta.26",
-        "web3-eth-personal": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-shh": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.26.tgz",
-      "integrity": "sha1-WFihjN5XaHSAGoPR30IJX8lYWQw=",
-      "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.37",
-        "underscore": "1.8.3"
+        "web3-bzz": "1.0.0-beta.29",
+        "web3-core": "1.0.0-beta.29",
+        "web3-eth": "1.0.0-beta.29",
+        "web3-eth-personal": "1.0.0-beta.29",
+        "web3-net": "1.0.0-beta.29",
+        "web3-shh": "1.0.0-beta.29",
+        "web3-utils": "1.0.0-beta.29"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        },
         "got": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -12397,282 +12397,258 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-        }
-      }
-    },
-    "web3-core": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.26.tgz",
-      "integrity": "sha1-hczKK2KfmK3+sOK21+K31nepeVk=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-requestmanager": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.26.tgz",
-      "integrity": "sha1-2G31xrMQ/FjFtv9Woz0mePu8PcM=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-method": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.26.tgz",
-      "integrity": "sha1-SdhpoacvMiNXbIkmCe7kDTsiVXw=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-promievent": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.26.tgz",
-      "integrity": "sha1-BkJSUZ35t+banCD1lKAuz+nDU8E=",
-      "requires": {
-        "bluebird": "3.3.1",
-        "eventemitter3": "1.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-        },
-        "eventemitter3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-        }
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.26.tgz",
-      "integrity": "sha1-dffvfy/GpLDTRr8AVCFXuB4UsDM=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-providers-http": "1.0.0-beta.26",
-        "web3-providers-ipc": "1.0.0-beta.26",
-        "web3-providers-ws": "1.0.0-beta.26"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.26.tgz",
-      "integrity": "sha1-0W0dbr3GDXCL9aR7hxZt1+jBl6A=",
-      "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-        }
-      }
-    },
-    "web3-eth": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.26.tgz",
-      "integrity": "sha1-aMAkw1a4ZWrDaVyPk9e2GzgQRKU=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-eth-abi": "1.0.0-beta.26",
-        "web3-eth-accounts": "1.0.0-beta.26",
-        "web3-eth-contract": "1.0.0-beta.26",
-        "web3-eth-iban": "1.0.0-beta.26",
-        "web3-eth-personal": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.26.tgz",
-      "integrity": "sha1-Ku3ASDxna1kcccBBJXIZj3omb+I=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.26.tgz",
-      "integrity": "sha1-N/18d3BCBGX95ZGCKYkad3OAehM=",
-      "requires": {
-        "bluebird": "3.3.1",
-        "eth-lib": "0.2.5",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-        },
-        "eth-lib": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.5.tgz",
-          "integrity": "sha512-pXs4ryU+7S8MPpkQpNqG4JlXEec87kbXowQbYzRVV+c5XUccrO6WOxVPDicxql1AXSBzfmBSFVkvvG+H4htuxg==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "elliptic": "6.4.0",
-            "xhr-request-promise": "0.1.2"
-          }
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.26.tgz",
-      "integrity": "sha1-fny3FXqrYMUi20353p3L2G2BOwk=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-promievent": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-eth-abi": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.26.tgz",
-      "integrity": "sha1-6MI2GOpapmJ73pHHPqi18ZGe43Q=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.26.tgz",
-      "integrity": "sha1-K4gDs01HJEfPW76BziVQSxMb7QY=",
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-net": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.26.tgz",
-      "integrity": "sha1-UY0oO1AANf7kgL9ocIljRyWrZLM=",
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.26.tgz",
-      "integrity": "sha1-GwFUu3UY027TT5EKZl5FFSoKyKE=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.26",
-        "xhr2": "0.1.4"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.26.tgz",
-      "integrity": "sha1-HffepV5nE1yQRaJsUzso0bbJ2mQ=",
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.26.tgz",
-      "integrity": "sha1-z0ylFUpPsVok1GgtEJUO4Emku2E=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.26",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.29.tgz",
+          "integrity": "sha1-xAVVzjKB9jf8X1yD3HsIy+70K3I=",
           "requires": {
-            "debug": "2.6.9",
-            "nan": "2.8.0",
-            "typedarray-to-buffer": "3.1.2",
-            "yaeti": "0.0.6"
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
           }
-        }
-      }
-    },
-    "web3-shh": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.26.tgz",
-      "integrity": "sha1-YMrff1V71rRRVHXd4z4uV7gKgg4=",
-      "requires": {
-        "web3-core": "1.0.0-beta.26",
-        "web3-core-method": "1.0.0-beta.26",
-        "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-net": "1.0.0-beta.26"
-      }
-    },
-    "web3-utils": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.26.tgz",
-      "integrity": "sha1-8ErYwUSxeBxrIMKBjgUyy55tyhU=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.8.3",
-        "utf8": "2.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.29.tgz",
+          "integrity": "sha1-G/uc3AHMPqcZDplh+PeIa7Qc/PE=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-core-requestmanager": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.29.tgz",
+          "integrity": "sha1-kUJt7MEEEmI4TA3quRvXmnCLGQI=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.29.tgz",
+          "integrity": "sha1-11trk9FuK5yoxPcc3G/ubCk2HHY=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-promievent": "1.0.0-beta.29",
+            "web3-core-subscriptions": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.29.tgz",
+          "integrity": "sha1-zziMs052BSiFp8K9Fec1jDm32Zg=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "eventemitter3": "1.1.1"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.29.tgz",
+          "integrity": "sha1-7s36oLtNJ8SEbEaFmJr2NVqxBzw=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-providers-http": "1.0.0-beta.29",
+            "web3-providers-ipc": "1.0.0-beta.29",
+            "web3-providers-ws": "1.0.0-beta.29"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.29.tgz",
+          "integrity": "sha1-D5R1q0diCQC4gsrILsQr3NNbRKE=",
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.29.tgz",
+          "integrity": "sha1-FTovYTcM50Qc4/JK5eFSC0K5PSQ=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-core-subscriptions": "1.0.0-beta.29",
+            "web3-eth-abi": "1.0.0-beta.29",
+            "web3-eth-accounts": "1.0.0-beta.29",
+            "web3-eth-contract": "1.0.0-beta.29",
+            "web3-eth-iban": "1.0.0-beta.29",
+            "web3-eth-personal": "1.0.0-beta.29",
+            "web3-net": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.29.tgz",
+          "integrity": "sha1-eRPArlRRAFmpjb0MubqG00IO+II=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.29.tgz",
+          "integrity": "sha1-mG/z7X0XHam6egPByblLMb4vk+w=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "xhr-request-promise": "0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.29.tgz",
+          "integrity": "sha1-xXTGOpCEi5gvF2tBwt76tFmMSmk=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-core-promievent": "1.0.0-beta.29",
+            "web3-core-subscriptions": "1.0.0-beta.29",
+            "web3-eth-abi": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.29.tgz",
+          "integrity": "sha1-eXSsE2X2WXdsxqv1xV4ty8Jw44E=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.29.tgz",
+          "integrity": "sha1-qk0e+k7hR4fzcnuxw2DxLtfIqqI=",
+          "requires": {
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-net": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.29.tgz",
+          "integrity": "sha1-8zYaw9o26FkB7hVh61K+5S2dS+4=",
+          "requires": {
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-utils": "1.0.0-beta.29"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.29.tgz",
+          "integrity": "sha1-UAFYhAnMKxj4qqwJINUuOQR+Ir0=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.29",
+            "xhr2": "0.1.4"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.29.tgz",
+          "integrity": "sha1-uMLaC1ql3KoqZc/tq/VXKyJV2rk=",
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.29.tgz",
+          "integrity": "sha1-LtnZsoj2IZs3+gV8XlsM/t3NAbs=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.29",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.29.tgz",
+          "integrity": "sha1-HnA1Utrpa/Z7Y+RoNRSxRV+aWEY=",
+          "requires": {
+            "web3-core": "1.0.0-beta.29",
+            "web3-core-method": "1.0.0-beta.29",
+            "web3-core-subscriptions": "1.0.0-beta.29",
+            "web3-net": "1.0.0-beta.29"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.29",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.29.tgz",
+          "integrity": "sha1-iZkl7RWyDV9wgU34o1Ji5Nb8pqk=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
         }
       }
     },
@@ -13011,6 +12987,15 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+      "requires": {
+        "debug": "2.6.9",
+        "nan": "2.8.0",
+        "typedarray-to-buffer": "3.1.2",
+        "yaeti": "0.0.6"
       }
     },
     "websocket-driver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12349,29 +12349,29 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.29.tgz",
-      "integrity": "sha1-6Xv9X94UWlAYFyTxd3+NuRg2YmA=",
+      "version": "1.0.0-beta.26",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
+      "integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.29",
-        "web3-core": "1.0.0-beta.29",
-        "web3-eth": "1.0.0-beta.29",
-        "web3-eth-personal": "1.0.0-beta.29",
-        "web3-net": "1.0.0-beta.29",
-        "web3-shh": "1.0.0-beta.29",
-        "web3-utils": "1.0.0-beta.29"
+        "web3-bzz": "1.0.0-beta.30",
+        "web3-core": "1.0.0-beta.30",
+        "web3-eth": "1.0.0-beta.30",
+        "web3-eth-personal": "1.0.0-beta.30",
+        "web3-net": "1.0.0-beta.30",
+        "web3-shh": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-bzz": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.30.tgz",
+      "integrity": "sha1-JDTaGDwjmqqlwBP2IwdCnqkd1wY=",
+      "requires": {
+        "got": "7.1.0",
+        "swarm-js": "0.1.37",
+        "underscore": "1.8.3"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-        },
-        "eventemitter3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-        },
         "got": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -12397,258 +12397,283 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        }
+      }
+    },
+    "web3-core": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.30.tgz",
+      "integrity": "sha1-919NO4W+dMdnRjeSHD4BO8XSdnk=",
+      "requires": {
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-core-requestmanager": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.30.tgz",
+      "integrity": "sha1-oADO4/CgnuoT10tXMDNdRjX+Hy8=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-eth-iban": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-core-method": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.30.tgz",
+      "integrity": "sha1-jdb/eJ6NFWO4eG0Tp4x/rO+uRxw=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-promievent": "1.0.0-beta.30",
+        "web3-core-subscriptions": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-core-promievent": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.30.tgz",
+      "integrity": "sha1-YgUZK/sJdEETIialk57FrtOoopE=",
+      "requires": {
+        "bluebird": "3.3.1",
+        "eventemitter3": "1.1.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        }
+      }
+    },
+    "web3-core-requestmanager": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.30.tgz",
+      "integrity": "sha1-buVvuKbLhf0BswgIVPUNZOUiQMY=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-providers-http": "1.0.0-beta.30",
+        "web3-providers-ipc": "1.0.0-beta.30",
+        "web3-providers-ws": "1.0.0-beta.30"
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.30.tgz",
+      "integrity": "sha1-MWUsdTVsP2floZzRS40xS61OISc=",
+      "requires": {
+        "eventemitter3": "1.1.1",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        }
+      }
+    },
+    "web3-eth": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.30.tgz",
+      "integrity": "sha1-ApsV4Uy2CLnP4CYDtQTWUYcPBQE=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-core-subscriptions": "1.0.0-beta.30",
+        "web3-eth-abi": "1.0.0-beta.30",
+        "web3-eth-accounts": "1.0.0-beta.30",
+        "web3-eth-contract": "1.0.0-beta.30",
+        "web3-eth-iban": "1.0.0-beta.30",
+        "web3-eth-personal": "1.0.0-beta.30",
+        "web3-net": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.30.tgz",
+      "integrity": "sha1-bqUsmZqFBbR8L4i6YdKmgKEGZAk=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.30.tgz",
+      "integrity": "sha1-jwobNCxCg4EjciQqbi3yaIh7O3A=",
+      "requires": {
+        "bluebird": "3.3.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.7",
+        "scrypt.js": "0.2.0",
+        "underscore": "1.8.3",
+        "uuid": "2.0.1",
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0",
+            "xhr-request-promise": "0.1.2"
+          }
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        },
-        "web3-bzz": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.29.tgz",
-          "integrity": "sha1-xAVVzjKB9jf8X1yD3HsIy+70K3I=",
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.30.tgz",
+      "integrity": "sha1-1+uiOFCE3/PHWqxII1ryyNLWolg=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-core-promievent": "1.0.0-beta.30",
+        "web3-core-subscriptions": "1.0.0-beta.30",
+        "web3-eth-abi": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.30.tgz",
+      "integrity": "sha1-OwgKXE2h+jdHexfkyQB4G5IVBkU=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.30.tgz",
+      "integrity": "sha1-i9TvQLO1+EHdOouXhz2dx5HK90g=",
+      "requires": {
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-net": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-net": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.30.tgz",
+      "integrity": "sha1-CjUu3ilubUt/iLZ6pHTklwPec78=",
+      "requires": {
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-utils": "1.0.0-beta.30"
+      }
+    },
+    "web3-providers-http": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.30.tgz",
+      "integrity": "sha1-zajZEzxvMdGoEtxaQq8Ay+qYzYY=",
+      "requires": {
+        "web3-core-helpers": "1.0.0-beta.30",
+        "xhr2": "0.1.4"
+      }
+    },
+    "web3-providers-ipc": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.30.tgz",
+      "integrity": "sha1-7i2NGKPxILd3BEpW5n4K7iCFRYc=",
+      "requires": {
+        "oboe": "2.1.3",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30"
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.30.tgz",
+      "integrity": "sha1-muaanq2Kh2H4Y3n6NHttta5EsS0=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.30",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
           "requires": {
-            "got": "7.1.0",
-            "swarm-js": "0.1.37",
-            "underscore": "1.8.3"
+            "debug": "2.6.9",
+            "nan": "2.8.0",
+            "typedarray-to-buffer": "3.1.2",
+            "yaeti": "0.0.6"
           }
-        },
-        "web3-core": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.29.tgz",
-          "integrity": "sha1-G/uc3AHMPqcZDplh+PeIa7Qc/PE=",
-          "requires": {
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-core-requestmanager": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.29.tgz",
-          "integrity": "sha1-kUJt7MEEEmI4TA3quRvXmnCLGQI=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-eth-iban": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.29.tgz",
-          "integrity": "sha1-11trk9FuK5yoxPcc3G/ubCk2HHY=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-promievent": "1.0.0-beta.29",
-            "web3-core-subscriptions": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.29.tgz",
-          "integrity": "sha1-zziMs052BSiFp8K9Fec1jDm32Zg=",
-          "requires": {
-            "bluebird": "3.3.1",
-            "eventemitter3": "1.1.1"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.29.tgz",
-          "integrity": "sha1-7s36oLtNJ8SEbEaFmJr2NVqxBzw=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-providers-http": "1.0.0-beta.29",
-            "web3-providers-ipc": "1.0.0-beta.29",
-            "web3-providers-ws": "1.0.0-beta.29"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.29.tgz",
-          "integrity": "sha1-D5R1q0diCQC4gsrILsQr3NNbRKE=",
-          "requires": {
-            "eventemitter3": "1.1.1",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29"
-          }
-        },
-        "web3-eth": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.29.tgz",
-          "integrity": "sha1-FTovYTcM50Qc4/JK5eFSC0K5PSQ=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-core-subscriptions": "1.0.0-beta.29",
-            "web3-eth-abi": "1.0.0-beta.29",
-            "web3-eth-accounts": "1.0.0-beta.29",
-            "web3-eth-contract": "1.0.0-beta.29",
-            "web3-eth-iban": "1.0.0-beta.29",
-            "web3-eth-personal": "1.0.0-beta.29",
-            "web3-net": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.29.tgz",
-          "integrity": "sha1-eRPArlRRAFmpjb0MubqG00IO+II=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            }
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.29.tgz",
-          "integrity": "sha1-mG/z7X0XHam6egPByblLMb4vk+w=",
-          "requires": {
-            "bluebird": "3.3.1",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "scrypt.js": "0.2.0",
-            "underscore": "1.8.3",
-            "uuid": "2.0.1",
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0",
-                "xhr-request-promise": "0.1.2"
-              }
-            }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.29.tgz",
-          "integrity": "sha1-xXTGOpCEi5gvF2tBwt76tFmMSmk=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-core-promievent": "1.0.0-beta.29",
-            "web3-core-subscriptions": "1.0.0-beta.29",
-            "web3-eth-abi": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.29.tgz",
-          "integrity": "sha1-eXSsE2X2WXdsxqv1xV4ty8Jw44E=",
-          "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.29.tgz",
-          "integrity": "sha1-qk0e+k7hR4fzcnuxw2DxLtfIqqI=",
-          "requires": {
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-net": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-net": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.29.tgz",
-          "integrity": "sha1-8zYaw9o26FkB7hVh61K+5S2dS+4=",
-          "requires": {
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-utils": "1.0.0-beta.29"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.29.tgz",
-          "integrity": "sha1-UAFYhAnMKxj4qqwJINUuOQR+Ir0=",
-          "requires": {
-            "web3-core-helpers": "1.0.0-beta.29",
-            "xhr2": "0.1.4"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.29.tgz",
-          "integrity": "sha1-uMLaC1ql3KoqZc/tq/VXKyJV2rk=",
-          "requires": {
-            "oboe": "2.1.3",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.29.tgz",
-          "integrity": "sha1-LtnZsoj2IZs3+gV8XlsM/t3NAbs=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.29",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-          }
-        },
-        "web3-shh": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.29.tgz",
-          "integrity": "sha1-HnA1Utrpa/Z7Y+RoNRSxRV+aWEY=",
-          "requires": {
-            "web3-core": "1.0.0-beta.29",
-            "web3-core-method": "1.0.0-beta.29",
-            "web3-core-subscriptions": "1.0.0-beta.29",
-            "web3-net": "1.0.0-beta.29"
-          }
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.29",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.29.tgz",
-          "integrity": "sha1-iZkl7RWyDV9wgU34o1Ji5Nb8pqk=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            }
-          }
+        }
+      }
+    },
+    "web3-shh": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.30.tgz",
+      "integrity": "sha1-K/4yINlY/0ylkgF3kIUrxXt7DKc=",
+      "requires": {
+        "web3-core": "1.0.0-beta.30",
+        "web3-core-method": "1.0.0-beta.30",
+        "web3-core-subscriptions": "1.0.0-beta.30",
+        "web3-net": "1.0.0-beta.30"
+      }
+    },
+    "web3-utils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.30.tgz",
+      "integrity": "sha1-6uQIzI1tb+zI1Ql8/q1Rdz8jH/k=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "eth-lib": "0.1.27",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randomhex": "0.1.5",
+        "underscore": "1.8.3",
+        "utf8": "2.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -12987,15 +13012,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-      "requires": {
-        "debug": "2.6.9",
-        "nan": "2.8.0",
-        "typedarray-to-buffer": "3.1.2",
-        "yaeti": "0.0.6"
       }
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
     "sweetalert": "^2.0.8",
-    "web3": "1.0.0-beta.26"
+    "web3": "1.0.0-beta.29"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
     "sweetalert": "^2.0.8",
-    "web3": "^1.0.0-beta.26"
+    "web3": "^1.0.0-beta.29"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
     "sweetalert": "^2.0.8",
-    "web3": "^1.0.0-beta.29"
+    "web3": "1.0.0-beta.26"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/src/App.js
+++ b/src/App.js
@@ -128,7 +128,7 @@ class App extends Component {
           await this.generateZip({mining, voting, payout, netIdName: this.state.web3Config.netIdName});
         } else {
           this.setState({loading: false, keysGenerated: false})
-
+          let content = document.createElement("div");
           let msg = `Transaction failed`;
           content.innerHTML = `<div>
             Something went wrong!<br/><br/>
@@ -144,7 +144,7 @@ class App extends Component {
       }).catch((error) => {
         console.error(error.message);
         this.setState({loading: false, keysGenerated: false})
-        var content = document.createElement("div");
+        let content = document.createElement("div");
         let msg;
         if (error.message.includes(constants.userDeniedTransactionPattern))
           msg = `Error: User ${constants.userDeniedTransactionPattern}`

--- a/src/App.js
+++ b/src/App.js
@@ -122,9 +122,25 @@ class App extends Component {
         sender: initialKey
       }).then(async (receipt) => {
         console.log(receipt);
-        this.setState({loading: false})
-        swal("Congratulations!", "Your keys are generated!", "success");
-        await this.generateZip({mining, voting, payout, netIdName: this.state.web3Config.netIdName});
+        if (receipt.status == "0x1") {
+          this.setState({loading: false})
+          swal("Congratulations!", "Your keys are generated!", "success");
+          await this.generateZip({mining, voting, payout, netIdName: this.state.web3Config.netIdName});
+        } else {
+          this.setState({loading: false, keysGenerated: false})
+
+          let msg = `Transaction failed`;
+          content.innerHTML = `<div>
+            Something went wrong!<br/><br/>
+            Please contact Master Of Ceremony<br/><br/>
+            ${msg}
+          </div>`;
+          swal({
+            icon: 'error',
+            title: 'Error',
+            content: content
+          });
+        }
       }).catch((error) => {
         console.error(error.message);
         this.setState({loading: false, keysGenerated: false})

--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,6 @@ import KeysManager from './keysManager';
 import Keys from './Keys';
 import swal from 'sweetalert';
 import './index/index.css';
-import ReactDOM from 'react-dom';
-import { error } from 'util';
 import addressGenerator from './addressGenerator'
 import JSzip from 'jszip';
 import FileSaver from 'file-saver';
@@ -28,11 +26,10 @@ class App extends Component {
     this.saveFile = (blob) => { 
       FileSaver.saveAs(blob, `poa_network_validator_keys.zip`);
     };
-    console.log(props)
     this.state = {
       web3Config: {},
       mining: null,
-      isDisabledBtn:  props.generateKeysIsDisabled
+      isDisabledBtn: props.generateKeysIsDisabled
     }
     this.keysManager = null;
     getWeb3().then(async (web3Config) => {

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import JSzip from 'jszip';
 import FileSaver from 'file-saver';
 import { constants } from './constants';
 import networkAddresses from './addresses';
+import Loading from './Loading';
 
 function generateElement(msg){
   let errorNode = document.createElement("div");
@@ -20,19 +21,6 @@ function generateElement(msg){
   return errorNode;
 }
 
-const Loading = () => (
-  <div className="loading-container">
-    <div className="loading">
-      <div className="loading-i"></div>
-      <div className="loading-i"></div>
-      <div className="loading-i"></div>
-      <div className="loading-i"></div>
-      <div className="loading-i"></div>
-      <div className="loading-i"></div>
-    </div>
-  </div>
-)
-
 class App extends Component {
   constructor(props){
     super(props);
@@ -40,10 +28,11 @@ class App extends Component {
     this.saveFile = (blob) => { 
       FileSaver.saveAs(blob, `poa_network_validator_keys.zip`);
     };
+    console.log(props)
     this.state = {
       web3Config: {},
       mining: null,
-      isDisabledBtn: false
+      isDisabledBtn:  props.generateKeysIsDisabled
     }
     this.keysManager = null;
     getWeb3().then(async (web3Config) => {
@@ -56,7 +45,10 @@ class App extends Component {
         netId: web3Config.netId,
         addresses,
       });
-      this.setState({web3Config})
+      this.setState({
+        isDisabledBtn: false,
+        web3Config
+      })
     }).catch((error) => {
       if(error.msg){
         this.setState({isDisabledBtn: true});

--- a/src/Loading.js
+++ b/src/Loading.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 const Loading = () => (
   <div className="loading-container">
     <div className="loading">

--- a/src/Loading.js
+++ b/src/Loading.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+const Loading = () => (
+  <div className="loading-container">
+    <div className="loading">
+      <div className="loading-i"></div>
+      <div className="loading-i"></div>
+      <div className="loading-i"></div>
+      <div className="loading-i"></div>
+      <div className="loading-i"></div>
+      <div className="loading-i"></div>
+    </div>
+  </div>
+)
+
+export default Loading;

--- a/src/addressGenerator.js
+++ b/src/addressGenerator.js
@@ -5,8 +5,6 @@ export default function generateAddress(cb) {
   return new Promise((resolve, reject) => {
     var params = { keyBytes: 32, ivBytes: 16 };
   
-    var dk = keythereum.create(params);
-  
     keythereum.create(params, function (dk) {
       var options = {};
       var password = passwordGenerator(20, false);

--- a/src/addresses.js
+++ b/src/addresses.js
@@ -1,7 +1,5 @@
-import { messages } from "./messages";
-import swal from 'sweetalert';
 import helpers from "./helpers";
-// const local = {
+//const local = {
 //    "KEYS_MANAGER_ADDRESS": "0x3ef32bb244016ad9af8c8f45398511e7e551b581"   
 //}
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,7 @@ import registerServiceWorker from './registerServiceWorker';
 window.addEventListener("beforeunload", function (event) {
   event.returnValue = "Are you sure?";
 });
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+	<App generateKeysIsDisabled={true} />
+, document.getElementById('root'));
 registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,5 @@ import registerServiceWorker from './registerServiceWorker';
 window.addEventListener("beforeunload", function (event) {
   event.returnValue = "Are you sure?";
 });
-ReactDOM.render(
-	<App generateKeysIsDisabled={true} />
-, document.getElementById('root'));
+ReactDOM.render(<App generateKeysIsDisabled={true} />, document.getElementById('root'));
 registerServiceWorker();


### PR DESCRIPTION
Closes https://github.com/poanetwork/poa-dapps-keys-generation/issues/65 

**Problem**: web3 or account is not loaded yet
**Solution**: *Generate keys button* is disabled until web3 is configured.

Successfully tested with automatic script `npm run start-test-setup-e2e-ceremony-test` from https://github.com/poanetwork/poa-test-setup