### PR TITLE
(Fix) Make Ceremony DApp use KeysManager.getInitialKeyStatus function

### DIFF
--- a/src/keysManager.js
+++ b/src/keysManager.js
@@ -9,18 +9,19 @@ export default class KeysManager {
     console.log('Keys Manager ', KEYS_MANAGER_ADDRESS);
     const branch = helpers.getBranch(netId);
 
-    let KeysManagerAbi = await helpers.getABI(branch, 'KeysManager')
+    const KeysManagerAbi = await helpers.getABI(branch, 'KeysManager')
 
     this.keysInstance = new this.web3_10.eth.Contract(KeysManagerAbi, KEYS_MANAGER_ADDRESS);
   }
 
   async isInitialKeyValid(initialKey) {
     return new Promise((resolve, reject) => {
+      const methods = this.keysInstance.methods
       let getInitialKeyStatus
-      if (this.keysInstance.methods.getInitialKeyStatus) {
-        getInitialKeyStatus = this.keysInstance.methods.getInitialKeyStatus
+      if (methods.getInitialKeyStatus) {
+        getInitialKeyStatus = methods.getInitialKeyStatus
       } else {
-        getInitialKeyStatus = this.keysInstance.methods.initialKeys
+        getInitialKeyStatus = methods.initialKeys
       }
       getInitialKeyStatus(initialKey).call().then(function(result){
         resolve(result);

--- a/src/keysManager.js
+++ b/src/keysManager.js
@@ -16,7 +16,13 @@ export default class KeysManager {
 
   async isInitialKeyValid(initialKey) {
     return new Promise((resolve, reject) => {
-      this.keysInstance.methods.initialKeys(initialKey).call().then(function(result){
+      let getInitialKeyStatus
+      if (this.keysInstance.methods.getInitialKeyStatus) {
+        getInitialKeyStatus = this.keysInstance.methods.getInitialKeyStatus
+      } else {
+        getInitialKeyStatus = this.keysInstance.methods.initialKeys
+      }
+      getInitialKeyStatus(initialKey).call().then(function(result){
         resolve(result);
       }).catch(function(e) {
         reject(false);


### PR DESCRIPTION
- (Mandatory) Description
These changes allow Ceremony DApp using `KeysManager.getInitialKeyStatus` function in the new version of `KeysManager` contract. That function was added in https://github.com/poanetwork/poa-network-consensus-contracts/pull/148. These changes are backward compatible and can be merged right now.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)