### PR TITLE
(Fix, Refactor) Add support of a new version of MetaMask

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ class App extends Component {
       await this.keysManager.init({
         web3: web3Config.web3Instance,
         netId: web3Config.netId,
-        addresses,
+        addresses
       });
       this.setState({
         isDisabledBtn: false,
@@ -99,7 +99,7 @@ class App extends Component {
   }
   async onClick() {
     this.setState({loading:true});
-    const initialKey = window.web3.eth.defaultAccount;
+    const initialKey = this.state.web3Config.defaultAccount;
     let isValid
     try {
       isValid = await this.keysManager.isInitialKeyValid(initialKey);

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -1,9 +1,10 @@
 import React from "react";
 import moment from "moment";
-import helpers from "./helpers";
+import { constants } from "./constants";
 
 const Footer = ({netId}) => {
-  const footerClassName = helpers.isTestnet(netId) ? "sokol" : "";
+  const footerClassName = netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET ? "sokol" : "";
+
   return (
   <footer className={`footer ${footerClassName}`}>
     <div className="container">

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import helpers from "./helpers";
+import { constants } from "./constants";
 
 let Header = ({netId}) => {
-  const thisIsTestnet = helpers.isTestnet(netId);
+  const thisIsTestnet = netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET;
   const headerClassName = thisIsTestnet ? "sokol" : "";
   const logoClassName = thisIsTestnet ? "header-logo-sokol" : "header-logo";
   return (

--- a/src/Loading.js
+++ b/src/Loading.js
@@ -8,16 +8,12 @@ const styles = (netId) => {
   const sokol = {
     backgroundColor: 'rgba(47, 109, 99, 0.8)'
   }
-  switch(netId) {
-    case constants.NETID_SOKOL:
-    case constants.NETID_DAI_TEST:
-      return sokol;
-    case constants.NETID_CORE:
-    case constants.NETID_DAI:
-      return core;
-    default:
-      return {};
+
+  if (netId in constants.NETWORKS) {
+    return constants.NETWORKS[netId].TESTNET ? sokol : core
   }
+
+  return core
 }
 const Loading = ({netId}) => (
   <div className="loading-container" style={styles(netId)}>

--- a/src/addresses.js
+++ b/src/addresses.js
@@ -5,23 +5,7 @@ import helpers from "./helpers";
 //}
 
 export default (web3Config) => {
-    let branch;
-    
-    switch (web3Config.netId) {
-        case constants.NETID_DAI_TEST:
-            branch = "dai-test";
-            break;
-        case constants.NETID_SOKOL:
-            branch = "sokol";
-            break;
-        case constants.NETID_DAI:
-            branch = "dai";
-            break;
-        case constants.NETID_CORE:
-        default:
-            branch = "core";
-            break;
-    }
+    const branch = constants.NETWORKS[web3Config.netId].BRANCH;
     return new Promise((resolve, reject) => {
         fetch(helpers.addressesURL(branch)).then((response) => { 
             response.json().then((json) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,25 +10,21 @@ constants.userDeniedTransactionPattern = 'User denied transaction';
 constants.NETWORKS = {
   '77': {
     NAME: 'Sokol',
-    RPC: 'https://sokol.poa.network',
     BRANCH: 'sokol',
     TESTNET: true
   },
   '99': {
     NAME: 'Core',
-    RPC: 'https://core.poa.network',
     BRANCH: 'core',
     TESTNET: false
   },
   '79': {
     NAME: 'Dai-Test',
-    RPC: 'http://40.112.48.125',
     BRANCH: 'dai-test',
     TESTNET: true
   },
   '100': {
     NAME: 'Dai',
-    RPC: 'https://dai.poa.network',
     BRANCH: 'dai',
     TESTNET: false
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,10 +7,32 @@ constants.ABIsSources = {
 };
 constants.userDeniedTransactionPattern = 'User denied transaction';
 
-constants.NETID_SOKOL = "77";
-constants.NETID_CORE = "99";
-constants.NETID_DAI_TEST = "79";
-constants.NETID_DAI = "100";
+constants.NETWORKS = {
+  '77': {
+    NAME: 'Sokol',
+    RPC: 'https://sokol.poa.network',
+    BRANCH: 'sokol',
+    TESTNET: true
+  },
+  '99': {
+    NAME: 'Core',
+    RPC: 'https://core.poa.network',
+    BRANCH: 'core',
+    TESTNET: false
+  },
+  '79': {
+    NAME: 'Dai-Test',
+    RPC: 'http://40.112.48.125',
+    BRANCH: 'dai-test',
+    TESTNET: true
+  },
+  '100': {
+    NAME: 'Dai',
+    RPC: 'https://dai.poa.network',
+    BRANCH: 'dai',
+    TESTNET: false
+  }
+};
 
 module.exports = {
   constants

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,65 +4,47 @@ import swal from 'sweetalert';
 
 var toAscii = function(hex) {
   var str = '',
-      i = 0,
-      l = hex.length;
+    i = 0,
+    l = hex.length;
   if (hex.substring(0, 2) === '0x') {
-      i = 2;
+    i = 2;
   }
   for (; i < l; i+=2) {
-      var code = parseInt(hex.substr(i, 2), 16);
-      if (code === 0) continue; // this is added
-      str += String.fromCharCode(code);
+    var code = parseInt(hex.substr(i, 2), 16);
+    if (code === 0) continue; // this is added
+    str += String.fromCharCode(code);
   }
   return str;
 };
 
 function addressesURL(branch) {
-    const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/${constants.addressesSourceFile}`;
-    return URL;
+  const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/${constants.addressesSourceFile}`;
+  return URL;
 }
 
 function ABIURL(branch, contract) {
-    const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/abis/${constants.ABIsSources[contract]}`;
-    return URL;
+  const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/abis/${constants.ABIsSources[contract]}`;
+  return URL;
 }
 
 function getABI(branch, contract) {
-    let addr = ABIURL(branch, contract);
-    return fetch(addr).then(function(response) {
-        return response.json();
-    })
+  let addr = ABIURL(branch, contract);
+  return fetch(addr).then(function(response) {
+      return response.json();
+  })
 }
 
 function wrongRepoAlert(addr) {
-    var content = document.createElement("div");
-    content.innerHTML = `<div>
-      Something went wrong!<br/><br/>
-      ${messages.wrongRepo(addr)}
-    </div>`;
-    swal({
-      icon: 'error',
-      title: 'Error',
-      content: content
-    });
-}
-
-function getBranch(netId) {
-    switch (netId) {
-        case constants.NETID_DAI_TEST:
-            return "dai-test";
-        case constants.NETID_SOKOL:
-            return "sokol";
-        case constants.NETID_DAI:
-            return "dai";
-        case constants.NETID_CORE:
-        default:
-            return "core";
-    }
-}
-
-function isTestnet(netId) {
-    return netId === constants.NETID_SOKOL || netId === constants.NETID_DAI_TEST;
+  var content = document.createElement("div");
+  content.innerHTML = `<div>
+    Something went wrong!<br/><br/>
+    ${messages.wrongRepo(addr)}
+  </div>`;
+  swal({
+    icon: 'error',
+    title: 'Error',
+    content: content
+  });
 }
 
 let helpers = {
@@ -70,9 +52,7 @@ let helpers = {
   addressesURL,
   ABIURL,
   getABI,
-  wrongRepoAlert,
-  getBranch,
-  isTestnet
+  wrongRepoAlert
 }
 
 export default helpers

--- a/src/keysManager.js
+++ b/src/keysManager.js
@@ -1,24 +1,27 @@
-import Web3 from 'web3';
 import addressGenerator from './addressGenerator';
 import helpers from "./helpers";
 import { constants } from "./constants";
 
 export default class KeysManager {
   async init({web3, netId, addresses}){
-    this.web3_10 = new Web3(web3.currentProvider);
     const {KEYS_MANAGER_ADDRESS} = addresses;
     console.log('Keys Manager ', KEYS_MANAGER_ADDRESS);
-    const branch = helpers.getBranch(netId);
 
-    const KeysManagerAbi = await helpers.getABI(branch, 'KeysManager')
+    const KeysManagerAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'KeysManager')
 
-    this.keysInstance = new this.web3_10.eth.Contract(KeysManagerAbi, KEYS_MANAGER_ADDRESS);
-    this.netId = netId;
+    this.instance = new web3.eth.Contract(KeysManagerAbi, KEYS_MANAGER_ADDRESS);
+
+    const networkName = constants.NETWORKS[netId].NAME.toLowerCase();
+    if (networkName === 'dai-test' || networkName === 'dai') {
+      this.gasPrice = web3.utils.toWei('0', 'gwei');
+    } else {
+      this.gasPrice = web3.utils.toWei('2', 'gwei');
+    }
   }
 
   async isInitialKeyValid(initialKey) {
     return new Promise((resolve, reject) => {
-      const methods = this.keysInstance.methods
+      const methods = this.instance.methods
       let getInitialKeyStatus
       if (methods.getInitialKeyStatus) {
         getInitialKeyStatus = methods.getInitialKeyStatus
@@ -37,14 +40,10 @@ export default class KeysManager {
     return await addressGenerator();
   }
 
-  createKeys({mining, voting, payout, sender}){
-    let gasPrice = '2';
-    if (this.netId === constants.NETID_DAI_TEST || this.netId === constants.NETID_DAI) {
-      gasPrice = '0';
-    }
-    return this.keysInstance.methods.createKeys(mining, voting, payout).send({
+  createKeys({mining, voting, payout, sender}) {
+    return this.instance.methods.createKeys(mining, voting, payout).send({
       from: sender,
-      gasPrice: this.web3_10.utils.toWei(gasPrice, 'gwei')
+      gasPrice: this.gasPrice
     });
   }
 }


### PR DESCRIPTION
- (Mandatory) Description

    This PR solves the issue https://github.com/poanetwork/poa-dapps-keys-generation/issues/83 and makes some refactoring of code. MetaMask v4.14.0 (and above) will display the next confirmation message when a user opens DApp for the first time after `November 2nd, 2018`:

    ![image](https://user-images.githubusercontent.com/33550681/46724947-c0123180-cc83-11e8-8d0f-fc881ac48b24.png)
    
    If the user clicks on `Approve`, the DApp will load and continue working. Otherwise (in the case of `Reject`), DApp will show the next alert and stop execution:

    ![image](https://user-images.githubusercontent.com/33550681/46725153-3ca51000-cc84-11e8-8655-560ceb739dd8.png)

    If the user clicks on `Approve`, MetaMask will cache user's choice and won't ask the user again next time until he/ she clears approval data in MetaMask's settings.

    The custom build of MetaMask for testing can be downloaded here: https://github.com/MetaMask/metamask-extension/pull/4703#issuecomment-427062852.

    These changes are backward compatible, so the new code will work fine with old DApp browsers that don't support `ethereum.enable()` feature yet.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix, Refactor)