### PR TITLE
(Fix) Remove xDai from the list of supported chains

### DIFF
--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import xDaiLogo from './xdai.svg'
+//import xDaiLogo from './xdai.svg'
 import poaLogo from './core.svg'
 import sokolLogo from './sokol.svg'
 import kovanLogo from './kovan.svg'
@@ -10,7 +10,7 @@ const getLogoSrc = networkBranch => {
       core: poaLogo,
       sokol: sokolLogo,
       kovan: kovanLogo,
-      dai: xDaiLogo
+      //dai: xDaiLogo
     }[networkBranch] || poaLogo
   )
 }

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { LogoPOA } from '../LogoPOA'
 import { LogoSokol } from '../LogoSokol'
 import { LogoKovan } from '../LogoKovan'
-import { LogoDai } from '../LogoDai'
+//import { LogoDai } from '../LogoDai'
 
 export const Logo = ({ href = null, extraClass = '', networkBranch = '' }) => {
   switch (networkBranch) {
@@ -10,8 +10,8 @@ export const Logo = ({ href = null, extraClass = '', networkBranch = '' }) => {
       return <LogoSokol href={href} extraClass={extraClass} />
     case 'kovan':
       return <LogoKovan href={href} extraClass={extraClass} />
-    case 'dai':
-      return <LogoDai href={href} extraClass={extraClass} />
+    //case 'dai':
+    //  return <LogoDai href={href} extraClass={extraClass} />
     case 'poa':
     default:
       return <LogoPOA href={href} extraClass={extraClass} />

--- a/src/components/SocialIcons/index.js
+++ b/src/components/SocialIcons/index.js
@@ -7,7 +7,7 @@ import { IconTwitter } from '../IconTwitter'
 const getIconBackgroundColor = networkBranch => {
   return (
     {
-      dai: '#e3e7e9',
+      //dai: '#e3e7e9',
       poa: '#fff',
       sokol: '#fff',
       kovan: '#fff'
@@ -18,7 +18,7 @@ const getIconBackgroundColor = networkBranch => {
 const getIconColor = networkBranch => {
   return (
     {
-      dai: '#333',
+      //dai: '#333',
       poa: '#5c34a2',
       sokol: '#6ac9b9',
       kovan: '#6ac9b9'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -24,11 +24,6 @@ constants.NETWORKS = {
     NAME: 'Core',
     BRANCH: 'core',
     TESTNET: false
-  },
-  '100': {
-    NAME: 'Dai',
-    BRANCH: 'dai',
-    TESTNET: false
   }
 }
 


### PR DESCRIPTION
- (Mandatory) Description
Since we switched the xDai chain to POSDAO consensus, Ceremony DApp makes no sense for xDai anymore. I removed the chain from the list of supported chains but left commented out its CSS components as they can be used by someone who may want to up the chain from scratch using the instruction https://www.xdaichain.com/for-developers/stable-chain-network-deployment

- (Mandatory) What is it: (Fix), (Feature), or (Refactor) in Title
(Fix)